### PR TITLE
Replaced @RequestMapping annotation with shortcut annotation for requested HTTP Method

### DIFF
--- a/src/main/java/com/project/controller/EditLoginDetailsController.java
+++ b/src/main/java/com/project/controller/EditLoginDetailsController.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,7 +45,7 @@ public class EditLoginDetailsController
 		}
 	}
 	
-	@RequestMapping(value="/newLoginDetails.html", method = RequestMethod.POST)
+	@PostMapping(value="/newLoginDetails.html")
 	public ModelAndView editLoginView(@RequestParam("username")String username,@RequestParam("password")String password, HttpServletRequest request)
 	{
 		try {

--- a/src/main/java/com/project/controller/LoginController.java
+++ b/src/main/java/com/project/controller/LoginController.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,7 +27,7 @@ public class LoginController
 	@Autowired
 	UsersInSystemDao dao2;
 	 
-	@RequestMapping(value="/login.html", method = RequestMethod.POST)
+	@PostMapping(value="/login.html")
 	public ModelAndView view()
 	{
 		try
@@ -47,7 +48,7 @@ public class LoginController
 	}
 	
 	
-	@RequestMapping(value="/dashboard.html", method = RequestMethod.POST)
+	@PostMapping(value="/dashboard.html")
 	public ModelAndView validate(@RequestParam("role")String role, @RequestParam("username")String username, @RequestParam("password")String password, HttpServletRequest request ) 
 	{
 		try {

--- a/src/main/java/com/project/controller/administrator/AddEmployeeController.java
+++ b/src/main/java/com/project/controller/administrator/AddEmployeeController.java
@@ -6,6 +6,7 @@ import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,7 +46,7 @@ public class AddEmployeeController
 		}
 	}
 	
-	@RequestMapping(value="/addEmployee.html", method = RequestMethod.POST)
+	@PostMapping(value="/addEmployee.html")
 	public ModelAndView add(@RequestParam("firstName")String firstName, @RequestParam("middleName")String middleName, @RequestParam("lastName")String lastName, @RequestParam("birthdate")String birthdate, @RequestParam("gender")String gender, @RequestParam("email")String email, @RequestParam("mobileNo")Long mobileNo, @RequestParam("adharNo")Long adharNo, @RequestParam("country")String country, @RequestParam("state")String state, @RequestParam("city")String city, @RequestParam("residentialAddress")String residentialAddress, @RequestParam("permanentAddress")String permanentAddress, @RequestParam("role")String role, @RequestParam("qualification")String qualification, @RequestParam("specialization")String specialization )
 	{	
 		try

--- a/src/main/java/com/project/controller/administrator/EditEmployeeController.java
+++ b/src/main/java/com/project/controller/administrator/EditEmployeeController.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -64,7 +65,7 @@ public class EditEmployeeController
 		}
 	}
 	
-	@RequestMapping(value="/editEmployeeView.html", method = RequestMethod.POST)
+	@PostMapping(value="/editEmployeeView.html")
 	public ModelAndView view(@RequestParam("eid")String eid)
 	{
 		ModelAndView mv= new ModelAndView();
@@ -73,7 +74,7 @@ public class EditEmployeeController
 		return mv;
 	}
 	
-	@RequestMapping(value="/editEmployee.html", method = RequestMethod.POST)
+	@PostMapping(value="/editEmployee.html")
 	public ModelAndView edit(@RequestParam("eid")String eid, @RequestParam("firstName")String firstName, @RequestParam("middleName")String middleName, @RequestParam("lastName")String lastName, @RequestParam("birthdate")String birthdate, @RequestParam("gender")String gender, @RequestParam("email")String email, @RequestParam("mobileNo")Long mobileNo, @RequestParam("adharNo")Long adharNo, @RequestParam("country")String country, @RequestParam("state")String state, @RequestParam("city")String city, @RequestParam("residentialAddress")String residentialAddress, @RequestParam("permanentAddress")String permanentAddress, @RequestParam("role")String role, @RequestParam("qualification")String qualification, @RequestParam("specialization")String specialization)
 	{
 		try {

--- a/src/main/java/com/project/controller/administrator/SearchEmployeeController.java
+++ b/src/main/java/com/project/controller/administrator/SearchEmployeeController.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,7 +36,7 @@ public class SearchEmployeeController
 		return mv;
 	}
 
-	@RequestMapping(value="/searchEmployeeByName.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchEmployeeByName.html")
 	public ModelAndView searchName(@RequestParam("firstName")String firstName, @RequestParam("lastName")String lastName )
 	{
 		Employee e1= dao.searchName(firstName,lastName);
@@ -59,7 +60,7 @@ public class SearchEmployeeController
 	    return null;
 	}
 	
-	@RequestMapping(value="/searchEmployeeById.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchEmployeeById.html")
 	public ModelAndView searchId(@RequestParam("id")String id)
 	{
 		Employee e1= dao.searchId(id);
@@ -83,7 +84,7 @@ public class SearchEmployeeController
 	    return null;
 	}
 	
-	@RequestMapping(value="/searchEmployeeByMobileNo.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchEmployeeByMobileNo.html")
 	public ModelAndView searchMobileNo(@RequestParam("mobileNo")String mobileNo)
 	{
 		Employee e1= dao.searchMobileNo(mobileNo);
@@ -107,7 +108,7 @@ public class SearchEmployeeController
 	    return null;
 	}
 	
-	@RequestMapping(value="/searchEmployeeByAadharNo.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchEmployeeByAadharNo.html")
 	public ModelAndView searchAadharNo(@RequestParam("aadharNo")String aadharNo)
 	{
 		Employee e1= dao.searchAadharNo(aadharNo);

--- a/src/main/java/com/project/controller/administrator/ShowAllEmployeeDetailsController.java
+++ b/src/main/java/com/project/controller/administrator/ShowAllEmployeeDetailsController.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,7 +37,7 @@ public class ShowAllEmployeeDetailsController
 		return mv;
 	}
 	
-	@RequestMapping(value = "/viewEmployee.html", method = RequestMethod.POST)
+	@PostMapping(value = "/viewEmployee.html")
 	public ModelAndView showEmployeeDetailsViewMethod(@RequestParam("eid")String eid)
 	{
 		try {

--- a/src/main/java/com/project/controller/doctor/DeleteDopdController.java
+++ b/src/main/java/com/project/controller/doctor/DeleteDopdController.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +25,7 @@ public class DeleteDopdController
 	@Autowired
 	DopdDetailsDao dao2;
 	
-	@RequestMapping(value = "/deleteDopd.html", method = RequestMethod.POST)
+	@PostMapping(value = "/deleteDopd.html")
 	public ModelAndView delete(@RequestParam("pid")String pid, HttpServletRequest request)
 	{
 		dao1.delete(pid);

--- a/src/main/java/com/project/controller/doctor/PatientDopdDetailsController.java
+++ b/src/main/java/com/project/controller/doctor/PatientDopdDetailsController.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,7 +24,7 @@ public class PatientDopdDetailsController
 	@Autowired
 	LoginDao infoLog;
 	
-	@RequestMapping(value="/viewDopdPatient1.html", method = RequestMethod.POST)
+	@PostMapping(value="/viewDopdPatient1.html")
 	public ModelAndView view(@RequestParam("pid")String pid, HttpServletRequest request)
 	{
 		try {

--- a/src/main/java/com/project/controller/doctor/PatientHistoryController.java
+++ b/src/main/java/com/project/controller/doctor/PatientHistoryController.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -58,7 +59,7 @@ public class PatientHistoryController
 		}
 	}
 	
-	@RequestMapping(value="/patientHistory.html", method = RequestMethod.POST)
+	@PostMapping(value="/patientHistory.html")
 	public ModelAndView showHistory(@RequestParam("opdid")String opdid) 
 	{
 		try

--- a/src/main/java/com/project/controller/opd/AddOpdController.java
+++ b/src/main/java/com/project/controller/opd/AddOpdController.java
@@ -2,6 +2,7 @@ package com.project.controller.opd;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +25,7 @@ public class AddOpdController
 	@Autowired
 	LoginDao infoLog;
 	
-	@RequestMapping(value = "/addOpd.html", method =RequestMethod.POST)
+	@PostMapping(value = "/addOpd.html")
 	public ModelAndView add(@RequestParam("pid")String pid)
 	{
 		try

--- a/src/main/java/com/project/controller/opd/DeleteOpdController.java
+++ b/src/main/java/com/project/controller/opd/DeleteOpdController.java
@@ -2,6 +2,7 @@ package com.project.controller.opd;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +25,7 @@ public class DeleteOpdController
 	@Autowired
 	LoginDao infoLog;
 	
-	@RequestMapping(value = "/deleteOpd.html", method = RequestMethod.POST)
+	@PostMapping(value = "/deleteOpd.html")
 	public ModelAndView delete(@RequestParam("pid")String pid)
 	{
 		try{

--- a/src/main/java/com/project/controller/receptionist/AddPatientController.java
+++ b/src/main/java/com/project/controller/receptionist/AddPatientController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -60,7 +61,7 @@ public class AddPatientController
 			}
 	}
 
-	@RequestMapping(value="/addPatient.html", method = RequestMethod.POST)
+	@PostMapping(value="/addPatient.html")
 	public ModelAndView add(@RequestParam("firstName")String firstName, @RequestParam("middleName")String middleName, @RequestParam("lastName")String lastName, @RequestParam("birthdate")String birthdate, @RequestParam("gender")String gender, @RequestParam("email")String email, @RequestParam("mobileNo")Long mobileNo, @RequestParam("adharNo")Long adharNo, @RequestParam("country")String country, @RequestParam("state")String state, @RequestParam("city")String city, @RequestParam("residentialAddress")String residentialAddress, @RequestParam("permanentAddress")String permanentAddress, @RequestParam("bloodGroup")String bloodGroup, @RequestParam("chronicDiseases")String chronicDiseases, @RequestParam("medicineAllergy")String medicineAllergy, @RequestParam("doctorId")String doctorId)
 	{	
 		//try{

--- a/src/main/java/com/project/controller/receptionist/EditPatientController.java
+++ b/src/main/java/com/project/controller/receptionist/EditPatientController.java
@@ -2,6 +2,7 @@ package com.project.controller.receptionist;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +34,7 @@ public class EditPatientController
 	@Autowired
 	LoginDao infoLog;
 	
-	@RequestMapping(value="/editPatientView.html", method=RequestMethod.POST)
+	@PostMapping(value="/editPatientView.html")
 	public ModelAndView edit(@RequestParam("pid")String pid)
 	{
 		try {
@@ -69,7 +70,7 @@ public class EditPatientController
 				
 	}
 
-	@RequestMapping(value="/editPatient.html", method = RequestMethod.POST)
+	@PostMapping(value="/editPatient.html")
 	public ModelAndView edit(@RequestParam("pid")String pid, @RequestParam("firstName")String firstName, @RequestParam("middleName")String middleName, @RequestParam("lastName")String lastName, @RequestParam("birthdate")String birthdate, @RequestParam("gender")String gender, @RequestParam("email")String email, @RequestParam("mobileNo")Long mobileNo, @RequestParam("adharNo")Long adharNo, @RequestParam("country")String country, @RequestParam("state")String state, @RequestParam("city")String city, @RequestParam("residentialAddress")String residentialAddress, @RequestParam("permanentAddress")String permanentAddress, @RequestParam("bloodGroup")String bloodGroup, @RequestParam("chronicDiseases")String chronicDiseases, @RequestParam("medicineAllergy")String medicineAllergy, @RequestParam("doctorId")String doctorId)
 	{
 		try {

--- a/src/main/java/com/project/controller/receptionist/PatientPrescriptionController.java
+++ b/src/main/java/com/project/controller/receptionist/PatientPrescriptionController.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -98,7 +99,7 @@ public class PatientPrescriptionController
 	
 	}
 	
-	@RequestMapping(value = "/prescriptionPrintDone.html", method = RequestMethod.POST)
+	@PostMapping(value = "/prescriptionPrintDone.html")
 	public ModelAndView delete(@RequestParam("pid")String pid)
 	{
 		try 

--- a/src/main/java/com/project/controller/receptionist/SearchPatientController.java
+++ b/src/main/java/com/project/controller/receptionist/SearchPatientController.java
@@ -2,6 +2,7 @@ package com.project.controller.receptionist;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,7 +36,7 @@ public class SearchPatientController
 		return mv;
 	}
 	
-	@RequestMapping(value="/searchPatientByName.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchPatientByName.html")
 	public ModelAndView searchName(@RequestParam("firstName")String firstName, @RequestParam("lastName")String lastName )
 	{
 		try {
@@ -72,7 +73,7 @@ public class SearchPatientController
 		}
 	}
 	
-	@RequestMapping(value="/searchPatientById.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchPatientById.html")
 	public ModelAndView searchId(@RequestParam("id")String pid)
 	{
 		try {
@@ -110,7 +111,7 @@ public class SearchPatientController
 		}
 	}
 
-	@RequestMapping(value="/searchPatientByMobileNo.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchPatientByMobileNo.html")
 	public ModelAndView searchMobileNo(@RequestParam("mobileNo")Long mobileNo)
 	{
 		try {
@@ -148,7 +149,7 @@ public class SearchPatientController
 		}
 	}	
 	
-	@RequestMapping(value="/searchPatientByAdharNo.html", method = RequestMethod.POST)
+	@PostMapping(value="/searchPatientByAdharNo.html")
 	public ModelAndView searchAdharNo(@RequestParam("aadharNo")Long adharNo)
 	{
 		try {


### PR DESCRIPTION
This change simplifies Spring Framework annotations by making use of shortened annotations when applicable.
Code that is easy to read is easy to review, reason about, and detect bugs in.

Making use of shortcut annotations accomplishes this by removing *wordy for no reason* elements.  


Version 4.3 of Spring Framework introduced method-level variants for `@RequestMapping`.
- `@GetMapping`
- `@PutMapping`
- `@PostMapping`
- `@DeleteMapping`
- `@PatchMapping`

```diff
- @RequestMapping(value = "/example", method = RequestMethod.GET)
  ...
+ @GetMapping(value = "/example")
```

<details>
  <summary>More reading</summary>

  * [https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-requestmapping.html](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-requestmapping.html)
  * [https://dzone.com/articles/using-the-spring-requestmapping-annotation](https://dzone.com/articles/using-the-spring-requestmapping-annotation)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/verbose-request-mapping](https://docs.pixee.ai/codemods/java/pixee_java_verbose-request-mapping)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FHospitalManagement%7Cb5c47e02dd3a34d9d0533d44adff1e399fb094d2)

<!--{"type":"DRIP","codemod":"pixee:java/verbose-request-mapping"}-->